### PR TITLE
[Feat]: 시간표 화면 api 구현

### DIFF
--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sookmyung.noonsongmaker.Dto.Response;
+import sookmyung.noonsongmaker.Dto.course.CoreResponseDto;
 import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
 import sookmyung.noonsongmaker.Dto.course.RequiredResponseDto;
 import sookmyung.noonsongmaker.Entity.User;
@@ -42,4 +43,12 @@ public class CourseController {
         return ResponseEntity.ok(Response.buildResponse(response, "수강해야 하는 교필 리스트"));
     }
 
+    @GetMapping("/core")
+    public ResponseEntity<Response<Map<String, CoreResponseDto>>> getCoreList(@CurrentUser User user) {
+        CoreResponseDto responseDto = courseService.getCoreList(user);
+
+        Map<String, CoreResponseDto> response = new HashMap<>();
+        response.put("core_list", responseDto);
+        return ResponseEntity.ok(Response.buildResponse(response, "교핵 영역별 수강 횟수"));
+    }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
@@ -1,6 +1,5 @@
 package sookmyung.noonsongmaker.Controller;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +10,7 @@ import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
 import sookmyung.noonsongmaker.Dto.course.RequiredResponseDto;
 import sookmyung.noonsongmaker.Dto.course.TimetableSubmitRequestDto;
 import sookmyung.noonsongmaker.Entity.User;
-import sookmyung.noonsongmaker.Service.CourseService;
+import sookmyung.noonsongmaker.Service.course.CourseService;
 import sookmyung.noonsongmaker.jwt.CurrentUser;
 
 import java.util.HashMap;

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
@@ -1,0 +1,36 @@
+package sookmyung.noonsongmaker.Controller;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sookmyung.noonsongmaker.Dto.Response;
+import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
+import sookmyung.noonsongmaker.Dto.course.RequiredResponseDto;
+import sookmyung.noonsongmaker.Entity.User;
+import sookmyung.noonsongmaker.Service.CourseService;
+import sookmyung.noonsongmaker.jwt.CurrentUser;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/course")
+@RequiredArgsConstructor
+@Slf4j
+public class CourseController {
+    private final CourseService courseService;
+
+    @GetMapping("/main")
+    public ResponseEntity<Response<Map<String, CreditResponseDto>>>  getCreditStatus(@CurrentUser User user) {
+        CreditResponseDto responseDto = courseService.getCurrentCreditStatus(user);
+        Map<String, CreditResponseDto> response = new HashMap<>();
+        response.put("current_credit", responseDto);
+        return ResponseEntity.ok(Response.buildResponse(response, "직전 학기까지의 수강 현황"));
+    }
+
+
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
@@ -4,13 +4,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sookmyung.noonsongmaker.Dto.Response;
 import sookmyung.noonsongmaker.Dto.course.CoreResponseDto;
 import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
 import sookmyung.noonsongmaker.Dto.course.RequiredResponseDto;
+import sookmyung.noonsongmaker.Dto.course.TimetableSubmitRequestDto;
 import sookmyung.noonsongmaker.Entity.User;
 import sookmyung.noonsongmaker.Service.CourseService;
 import sookmyung.noonsongmaker.jwt.CurrentUser;
@@ -50,5 +49,11 @@ public class CourseController {
         Map<String, CoreResponseDto> response = new HashMap<>();
         response.put("core_list", responseDto);
         return ResponseEntity.ok(Response.buildResponse(response, "교핵 영역별 수강 횟수"));
+    }
+
+    @PatchMapping("/submit")
+    public ResponseEntity<Response<String>> submitTimetable(@CurrentUser User user, @RequestBody TimetableSubmitRequestDto timetableSubmitRequestDto) {
+        courseService.updateTimetable(user, timetableSubmitRequestDto);
+        return ResponseEntity.ok(Response.buildResponse(null, "확정 시간표"));
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
@@ -5,10 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sookmyung.noonsongmaker.Dto.Response;
-import sookmyung.noonsongmaker.Dto.course.CoreResponseDto;
-import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
-import sookmyung.noonsongmaker.Dto.course.RequiredResponseDto;
-import sookmyung.noonsongmaker.Dto.course.TimetableSubmitRequestDto;
+import sookmyung.noonsongmaker.Dto.course.*;
 import sookmyung.noonsongmaker.Entity.User;
 import sookmyung.noonsongmaker.Service.course.CourseService;
 import sookmyung.noonsongmaker.jwt.CurrentUser;
@@ -51,8 +48,8 @@ public class CourseController {
     }
 
     @PatchMapping("/submit")
-    public ResponseEntity<Response<String>> submitTimetable(@CurrentUser User user, @RequestBody TimetableSubmitRequestDto timetableSubmitRequestDto) {
-        courseService.updateTimetable(user, timetableSubmitRequestDto);
-        return ResponseEntity.ok(Response.buildResponse(null, "확정 시간표"));
+    public ResponseEntity<Response<TimetableSubmitResponseDto>> submitTimetable(@CurrentUser User user, @RequestBody TimetableSubmitRequestDto timetableSubmitRequestDto) {
+        TimetableSubmitResponseDto responseDto = courseService.updateTimetable(user, timetableSubmitRequestDto);
+        return ResponseEntity.ok(Response.buildResponse(responseDto, "확정 시간표"));
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Controller/CourseController.java
@@ -27,10 +27,19 @@ public class CourseController {
     @GetMapping("/main")
     public ResponseEntity<Response<Map<String, CreditResponseDto>>>  getCreditStatus(@CurrentUser User user) {
         CreditResponseDto responseDto = courseService.getCurrentCreditStatus(user);
+
         Map<String, CreditResponseDto> response = new HashMap<>();
         response.put("current_credit", responseDto);
         return ResponseEntity.ok(Response.buildResponse(response, "직전 학기까지의 수강 현황"));
     }
 
+    @GetMapping("/required")
+    public ResponseEntity<Response<Map<String, RequiredResponseDto>>> getRequiredList(@CurrentUser User user) {
+        RequiredResponseDto responseDto = courseService.getRequiredList(user);
+
+        Map<String, RequiredResponseDto> response = new HashMap<>();
+        response.put("required_list", responseDto);
+        return ResponseEntity.ok(Response.buildResponse(response, "수강해야 하는 교필 리스트"));
+    }
 
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/CoreResponseDto.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/CoreResponseDto.java
@@ -1,0 +1,20 @@
+package sookmyung.noonsongmaker.Dto.course;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CoreResponseDto {
+    @JsonProperty("교핵_1영역")
+    private Short core1;
+    @JsonProperty("교핵_2영역")
+    private Short core2;
+    @JsonProperty("교핵_3영역")
+    private Short core3;
+    @JsonProperty("교핵_4영역")
+    private Short core4;
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/CreditResponseDto.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/CreditResponseDto.java
@@ -1,0 +1,23 @@
+package sookmyung.noonsongmaker.Dto.course;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sookmyung.noonsongmaker.Entity.Chapter;
+import sookmyung.noonsongmaker.Entity.MajorType;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreditResponseDto {
+    private Chapter semester;
+    private String major;
+    private MajorType majorType;
+    private Integer CurrentCoreCredits;
+    private Integer CurrentElectivesCredits;
+
+
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/RequiredResponseDto.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/RequiredResponseDto.java
@@ -1,0 +1,14 @@
+package sookmyung.noonsongmaker.Dto.course;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequiredResponseDto {
+    private Boolean isRequiredDigital;
+    private Boolean isRequiredFuture;
+    private Boolean isRequiredEng;
+    private Boolean isRequiredLogic;}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/RequiredResponseDto.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/RequiredResponseDto.java
@@ -10,11 +10,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RequiredResponseDto {
     @JsonProperty("디사의")
-    private Boolean isRequiredDigital;
+    private Boolean requiredDigital;
     @JsonProperty("미래설계")
-    private Boolean isRequiredFuture;
+    private Boolean requiredFuture;
     @JsonProperty("영교필")
-    private Boolean isRequiredEng;
+    private Boolean requiredEng;
     @JsonProperty("논사소")
-    private Boolean isRequiredLogic;
+    private Boolean requiredLogic;
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/RequiredResponseDto.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/RequiredResponseDto.java
@@ -1,5 +1,6 @@
 package sookmyung.noonsongmaker.Dto.course;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RequiredResponseDto {
+    @JsonProperty("디사의")
     private Boolean isRequiredDigital;
+    @JsonProperty("미래설계")
     private Boolean isRequiredFuture;
+    @JsonProperty("영교필")
     private Boolean isRequiredEng;
-    private Boolean isRequiredLogic;}
+    @JsonProperty("논사소")
+    private Boolean isRequiredLogic;
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/TimetableSubmitRequestDto.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/TimetableSubmitRequestDto.java
@@ -1,0 +1,21 @@
+package sookmyung.noonsongmaker.Dto.course;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TimetableSubmitRequestDto {
+    private Integer coreCredits;
+    private Integer electiveCredits;
+
+    private Boolean requiredDigital;
+    private Boolean requiredFuture;
+    private Boolean requiredEng;
+    private Boolean requiredLogic;
+
+    private Short core1;
+    private Short core2;
+    private Short core3;
+    private Short core4;
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/TimetableSubmitResponseDto.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Dto/course/TimetableSubmitResponseDto.java
@@ -1,0 +1,14 @@
+package sookmyung.noonsongmaker.Dto.course;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TimetableSubmitResponseDto {
+    private Map<String, Boolean> updateResults;
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Chapter.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Chapter.java
@@ -1,5 +1,7 @@
 package sookmyung.noonsongmaker.Entity;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum Chapter {
     SEM_S_1, VAC_S_1, SEM_W_1, VAC_W_1,
     SEM_S_2, VAC_S_2, SEM_W_2, VAC_W_2,
@@ -8,5 +10,10 @@ public enum Chapter {
     SEM_S_5, VAC_S_5, SEM_W_5, VAC_W_5,
     SEM_S_6, VAC_S_6, SEM_W_6, VAC_W_6,
     SEM_S_7, VAC_S_7, SEM_W_7, VAC_W_7,
-    SEM_S_8, VAC_S_8, SEM_W_8, VAC_W_8
+    SEM_S_8, VAC_S_8, SEM_W_8, VAC_W_8;
+
+    @JsonValue
+    public String toJson() {
+        return this.name();
+    }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Chapter.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Chapter.java
@@ -6,11 +6,7 @@ public enum Chapter {
     SEM_S_1, VAC_S_1, SEM_W_1, VAC_W_1,
     SEM_S_2, VAC_S_2, SEM_W_2, VAC_W_2,
     SEM_S_3, VAC_S_3, SEM_W_3, VAC_W_3,
-    SEM_S_4, VAC_S_4, SEM_W_4, VAC_W_4,
-    SEM_S_5, VAC_S_5, SEM_W_5, VAC_W_5,
-    SEM_S_6, VAC_S_6, SEM_W_6, VAC_W_6,
-    SEM_S_7, VAC_S_7, SEM_W_7, VAC_W_7,
-    SEM_S_8, VAC_S_8, SEM_W_8, VAC_W_8;
+    SEM_S_4, VAC_S_4, SEM_W_4, VAC_W_4;
 
     @JsonValue
     public String toJson() {

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Course.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Course.java
@@ -2,7 +2,6 @@ package sookmyung.noonsongmaker.Entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import sookmyung.noonsongmaker.Dto.course.TimetableSubmitRequestDto;
 
 @Entity
 @Getter
@@ -34,22 +33,36 @@ public class Course {
     private Short core3;
     private Short core4;
 
-    public void updateCredits(Integer core, Integer elective) {
-        if (core != null) this.coreCredits = core;
-        if (elective != null) this.electiveCredits = elective;
+    public void updateCoreCredits(Integer core) {
+        if (core != null) this.coreCredits += core;
+    }
+    public void updateElectiveCredits(Integer elective) {
+        if (elective != null) this.electiveCredits += elective;
     }
 
-    public void updateRequired(Boolean digital, Boolean future, Boolean eng, Boolean logic) {
+    public void updateRequiredDigital(Boolean digital) {
         if (digital != null) this.requiredDigital = digital;
+    }
+    public void updateRequiredFuture(Boolean future) {
         if (future != null) this.requiredFuture = future;
+    }
+    public void updateRequiredEng(Boolean eng) {
         if (eng != null) this.requiredEng = eng;
+    }
+    public void updateRequiredLogic(Boolean logic) {
         if (logic != null) this.requiredLogic = logic;
     }
 
-    public void updateCore(Short core1, Short core2, Short core3, Short core4) {
-        if (core1 != null) this.core1 = core1;
-        if (core2 != null) this.core2 = core2;
-        if (core3 != null) this.core3 = core3;
-        if (core4 != null) this.core4 = core4;
+    public void updateCore1(Short core1) {
+        if (core1 != null) this.core1 = (short)(this.core1 + core1);
+    }
+    public void updateCore2(Short core2) {
+        if (core2 != null) this.core2 = (short)(this.core2 + core2);
+    }
+    public void updateCore3(Short core3) {
+        if (core3 != null) this.core3 = (short)(this.core3 + core3);
+    }
+    public void updateCore4(Short core4) {
+        if (core4 != null) this.core4 = (short)(this.core4 + core4);
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Course.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Course.java
@@ -2,6 +2,7 @@ package sookmyung.noonsongmaker.Entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import sookmyung.noonsongmaker.Dto.course.TimetableSubmitRequestDto;
 
 @Entity
 @Getter
@@ -20,16 +21,18 @@ public class Course {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private Integer CoreCredits;
-    private Integer ElectiveCredits;
+    private Integer coreCredits;
+    private Integer electiveCredits;
 
-    private Boolean isRequiredDigital;
-    private Boolean isRequiredFuture;
-    private Boolean isRequiredEng;
-    private Boolean isRequiredLogic;
+    private Boolean requiredDigital;
+    private Boolean requiredFuture;
+    private Boolean requiredEng;
+    private Boolean requiredLogic;
 
-    private Short isCore1;
-    private Short isCore2;
-    private Short isCore3;
-    private Short isCore4;
+    private Short core1;
+    private Short core2;
+    private Short core3;
+    private Short core4;
+
+
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Course.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Course.java
@@ -34,5 +34,18 @@ public class Course {
     private Short core3;
     private Short core4;
 
+    public void updateCourse(TimetableSubmitRequestDto dto) {
+        if (dto.getCoreCredits() != null) this.coreCredits = dto.getCoreCredits();
+        if (dto.getElectiveCredits() != null) this.electiveCredits = dto.getElectiveCredits();
 
+        if (dto.getRequiredDigital() != null) this.requiredDigital = dto.getRequiredDigital();
+        if (dto.getRequiredFuture() != null) this.requiredFuture = dto.getRequiredFuture();
+        if (dto.getRequiredEng() != null) this.requiredEng = dto.getRequiredEng();
+        if (dto.getRequiredLogic() != null) this.requiredLogic = dto.getRequiredLogic();
+
+        if (dto.getCore1() != null) this.core1 = dto.getCore1();
+        if (dto.getCore2() != null) this.core2 = dto.getCore2();
+        if (dto.getCore3() != null) this.core3 = dto.getCore3();
+        if (dto.getCore4() != null) this.core4 = dto.getCore4();
+    }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Course.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/Course.java
@@ -34,18 +34,22 @@ public class Course {
     private Short core3;
     private Short core4;
 
-    public void updateCourse(TimetableSubmitRequestDto dto) {
-        if (dto.getCoreCredits() != null) this.coreCredits = dto.getCoreCredits();
-        if (dto.getElectiveCredits() != null) this.electiveCredits = dto.getElectiveCredits();
+    public void updateCredits(Integer core, Integer elective) {
+        if (core != null) this.coreCredits = core;
+        if (elective != null) this.electiveCredits = elective;
+    }
 
-        if (dto.getRequiredDigital() != null) this.requiredDigital = dto.getRequiredDigital();
-        if (dto.getRequiredFuture() != null) this.requiredFuture = dto.getRequiredFuture();
-        if (dto.getRequiredEng() != null) this.requiredEng = dto.getRequiredEng();
-        if (dto.getRequiredLogic() != null) this.requiredLogic = dto.getRequiredLogic();
+    public void updateRequired(Boolean digital, Boolean future, Boolean eng, Boolean logic) {
+        if (digital != null) this.requiredDigital = digital;
+        if (future != null) this.requiredFuture = future;
+        if (eng != null) this.requiredEng = eng;
+        if (logic != null) this.requiredLogic = logic;
+    }
 
-        if (dto.getCore1() != null) this.core1 = dto.getCore1();
-        if (dto.getCore2() != null) this.core2 = dto.getCore2();
-        if (dto.getCore3() != null) this.core3 = dto.getCore3();
-        if (dto.getCore4() != null) this.core4 = dto.getCore4();
+    public void updateCore(Short core1, Short core2, Short core3, Short core4) {
+        if (core1 != null) this.core1 = core1;
+        if (core2 != null) this.core2 = core2;
+        if (core3 != null) this.core3 = core3;
+        if (core4 != null) this.core4 = core4;
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/MajorType.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/MajorType.java
@@ -1,0 +1,12 @@
+package sookmyung.noonsongmaker.Entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum MajorType {
+    DOUBLE_MAJOR, SUB_MAJOR, ADVANCED_MAJOR;
+
+    @JsonValue
+    public String toJson() {
+        return this.name();
+    }
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/UserProfile.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/UserProfile.java
@@ -37,6 +37,12 @@ public class UserProfile{
 
     @Column(nullable = false, length = 10)
     private String dream;
+
+    private String major;
+
+    @Enumerated(EnumType.STRING)
+    private MajorType majorType;
+
 }
 
 enum MBTI {

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Repository/CourseRepository.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Repository/CourseRepository.java
@@ -1,0 +1,4 @@
+package sookmyung.noonsongmaker.Repository;
+
+public class CourseRepository {
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Repository/UserProfileRepository.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Repository/UserProfileRepository.java
@@ -2,12 +2,12 @@ package sookmyung.noonsongmaker.Repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import sookmyung.noonsongmaker.Entity.Course;
 import sookmyung.noonsongmaker.Entity.User;
+import sookmyung.noonsongmaker.Entity.UserProfile;
 
 import java.util.Optional;
 
 @Repository
-public interface CourseRepository extends JpaRepository<Course, Long> {
-    Optional<Course> findByUser(User user);
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+    Optional<UserProfile> findByUser(User user);
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Repository/UserRepository.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Repository/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
@@ -3,6 +3,7 @@ package sookmyung.noonsongmaker.Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
+import sookmyung.noonsongmaker.Dto.course.RequiredResponseDto;
 import sookmyung.noonsongmaker.Entity.Course;
 import sookmyung.noonsongmaker.Entity.User;
 import sookmyung.noonsongmaker.Entity.UserProfile;
@@ -30,6 +31,18 @@ public class CourseService {
                 .majorType(userProfileResult.getMajorType())
                 .CurrentCoreCredits(courseResult.getCoreCredits())
                 .CurrentElectivesCredits(courseResult.getElectiveCredits())
+                .build();
+    }
+
+    public RequiredResponseDto getRequiredList(User user) {
+        Course courseResult = courseRepository.findByUser(user)
+                .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
+
+        return RequiredResponseDto.builder()
+                .isRequiredDigital(courseResult.getIsRequiredDigital())
+                .isRequiredFuture(courseResult.getIsRequiredFuture())
+                .isRequiredEng(courseResult.getIsRequiredEng())
+                .isRequiredLogic(courseResult.getIsRequiredLogic())
                 .build();
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
@@ -2,9 +2,7 @@ package sookmyung.noonsongmaker.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import sookmyung.noonsongmaker.Dto.course.CoreResponseDto;
-import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
-import sookmyung.noonsongmaker.Dto.course.RequiredResponseDto;
+import sookmyung.noonsongmaker.Dto.course.*;
 import sookmyung.noonsongmaker.Entity.Course;
 import sookmyung.noonsongmaker.Entity.User;
 import sookmyung.noonsongmaker.Entity.UserProfile;
@@ -40,10 +38,10 @@ public class CourseService {
                 .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
 
         return RequiredResponseDto.builder()
-                .isRequiredDigital(courseResult.getIsRequiredDigital())
-                .isRequiredFuture(courseResult.getIsRequiredFuture())
-                .isRequiredEng(courseResult.getIsRequiredEng())
-                .isRequiredLogic(courseResult.getIsRequiredLogic())
+                .requiredDigital(courseResult.getRequiredDigital())
+                .requiredFuture(courseResult.getRequiredFuture())
+                .requiredEng(courseResult.getRequiredEng())
+                .requiredLogic(courseResult.getRequiredLogic())
                 .build();
     }
 
@@ -52,10 +50,10 @@ public class CourseService {
                 .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
 
         return CoreResponseDto.builder()
-                .core1(courseResult.getIsCore1())
-                .core2(courseResult.getIsCore2())
-                .core3(courseResult.getIsCore3())
-                .core4(courseResult.getIsCore4())
+                .core1(courseResult.getCore1())
+                .core2(courseResult.getCore2())
+                .core3(courseResult.getCore3())
+                .core4(courseResult.getCore4())
                 .build();
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
@@ -1,0 +1,35 @@
+package sookmyung.noonsongmaker.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
+import sookmyung.noonsongmaker.Entity.Course;
+import sookmyung.noonsongmaker.Entity.User;
+import sookmyung.noonsongmaker.Entity.UserProfile;
+import sookmyung.noonsongmaker.Repository.CourseRepository;
+import sookmyung.noonsongmaker.Repository.UserProfileRepository;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+    private final CourseRepository courseRepository;
+    private final UserProfileRepository userProfileRepository;
+
+    public CreditResponseDto getCurrentCreditStatus(User user) {
+        Course courseResult = courseRepository.findByUser(user)
+                .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
+        UserProfile userProfileResult = userProfileRepository.findByUser(user)
+                .orElseThrow(() -> new NoSuchElementException("사용자 없음"));
+
+
+        return CreditResponseDto.builder()
+                .semester(user.getCurrentChapter())
+                .major(userProfileResult.getMajor())
+                .majorType(userProfileResult.getMajorType())
+                .CurrentCoreCredits(courseResult.getCoreCredits())
+                .CurrentElectivesCredits(courseResult.getElectiveCredits())
+                .build();
+    }
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
@@ -1,5 +1,6 @@
 package sookmyung.noonsongmaker.Service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import sookmyung.noonsongmaker.Dto.course.*;
@@ -55,5 +56,13 @@ public class CourseService {
                 .core3(courseResult.getCore3())
                 .core4(courseResult.getCore4())
                 .build();
+    }
+
+    @Transactional
+    public void updateTimetable(User user, TimetableSubmitRequestDto requestDto) {
+        Course course = courseRepository.findByUser(user)
+                .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
+
+        course.updateCourse(requestDto);
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/CourseService.java
@@ -2,6 +2,7 @@ package sookmyung.noonsongmaker.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import sookmyung.noonsongmaker.Dto.course.CoreResponseDto;
 import sookmyung.noonsongmaker.Dto.course.CreditResponseDto;
 import sookmyung.noonsongmaker.Dto.course.RequiredResponseDto;
 import sookmyung.noonsongmaker.Entity.Course;
@@ -43,6 +44,18 @@ public class CourseService {
                 .isRequiredFuture(courseResult.getIsRequiredFuture())
                 .isRequiredEng(courseResult.getIsRequiredEng())
                 .isRequiredLogic(courseResult.getIsRequiredLogic())
+                .build();
+    }
+
+    public CoreResponseDto getCoreList(User user) {
+        Course courseResult = courseRepository.findByUser(user)
+                .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
+
+        return CoreResponseDto.builder()
+                .core1(courseResult.getIsCore1())
+                .core2(courseResult.getIsCore2())
+                .core3(courseResult.getIsCore3())
+                .core4(courseResult.getIsCore4())
                 .build();
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/course/CourseService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/course/CourseService.java
@@ -10,6 +10,8 @@ import sookmyung.noonsongmaker.Entity.UserProfile;
 import sookmyung.noonsongmaker.Repository.CourseRepository;
 import sookmyung.noonsongmaker.Repository.UserProfileRepository;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 @Service
@@ -59,46 +61,68 @@ public class CourseService {
     }
 
     @Transactional
-    public void updateTimetable(User user, TimetableSubmitRequestDto requestDto) {
+    public TimetableSubmitResponseDto updateTimetable(User user, TimetableSubmitRequestDto requestDto) {
         Course course = courseRepository.findByUser(user)
                 .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
         TimetableUpdatePolicy policy = new TimetableUpdatePolicy(user.getCurrentChapter());
+        Map<String, Boolean> results = new HashMap<>();
 
-        if (requestDto.getCoreCredits() != null && policy.isMajorUpdatePossible()) {
-            course.updateCoreCredits(requestDto.getCoreCredits());
-            // TODO responseDto에 결과 저장 : 프론트와 형식 협의 필요
+        if (requestDto.getCoreCredits() != null) {
+            boolean updated = policy.isMajorUpdatePossible();
+            if (updated) course.updateCoreCredits(requestDto.getCoreCredits());
+            results.put("coreCredits", updated);
         }
-        if (requestDto.getElectiveCredits() != null && policy.isMajorUpdatePossible()) {
-            course.updateElectiveCredits(requestDto.getElectiveCredits());
-        }
-
-        if (requestDto.getRequiredDigital() != null && policy.isLibUpdatePossible()) {
-            course.updateRequiredDigital(requestDto.getRequiredDigital());
-        }
-        if (requestDto.getRequiredFuture() != null && policy.isLibUpdatePossible()) {
-            course.updateRequiredFuture(requestDto.getRequiredFuture());
-        }
-        if (requestDto.getRequiredEng() != null && policy.isLibUpdatePossible()) {
-            course.updateRequiredEng(requestDto.getRequiredEng());
-        }
-        if (requestDto.getRequiredLogic() != null && policy.isLibUpdatePossible()) {
-            course.updateRequiredLogic(requestDto.getRequiredLogic());
+        if (requestDto.getElectiveCredits() != null) {
+            boolean updated = policy.isMajorUpdatePossible();
+            if (updated) course.updateElectiveCredits(requestDto.getElectiveCredits());
+            results.put("electiveCredits", updated);
         }
 
-        if (requestDto.getCore1() != null && policy.isLibUpdatePossible()) {
-            course.updateCore1(requestDto.getCore1());
+        if (requestDto.getRequiredDigital() != null) {
+            boolean updated = policy.isLibUpdatePossible();
+            if (updated) course.updateRequiredDigital(requestDto.getRequiredDigital());
+            results.put("requiredDigital", updated);
         }
-        if (requestDto.getCore2() != null && policy.isLibUpdatePossible()) {
-            course.updateCore2(requestDto.getCore2());
+        if (requestDto.getRequiredFuture() != null) {
+            boolean updated = policy.isLibUpdatePossible();
+            if (updated) course.updateRequiredFuture(requestDto.getRequiredFuture());
+            results.put("requiredFuture", updated);
         }
-        if (requestDto.getCore3() != null && policy.isLibUpdatePossible()) {
-            course.updateCore3(requestDto.getCore3());
+        if (requestDto.getRequiredEng() != null) {
+            boolean updated = policy.isLibUpdatePossible();
+            if (updated) course.updateRequiredEng(requestDto.getRequiredEng());
+            results.put("requiredEng", updated);
         }
-        if (requestDto.getCore4() != null && policy.isLibUpdatePossible()) {
-            course.updateCore4(requestDto.getCore4());
+        if (requestDto.getRequiredLogic() != null) {
+            boolean updated = policy.isLibUpdatePossible();
+            if (updated) course.updateRequiredLogic(requestDto.getRequiredLogic());
+            results.put("requiredLogic", updated);
         }
 
+        if (requestDto.getCore1() != null) {
+            boolean updated = policy.isLibUpdatePossible();
+            if (updated) course.updateCore1(requestDto.getCore1());
+            results.put("core1", updated);
+        }
+        if (requestDto.getCore2() != null) {
+            boolean updated = policy.isLibUpdatePossible();
+            if (updated)course.updateCore2(requestDto.getCore2());
+            results.put("core2", updated);
+        }
+        if (requestDto.getCore3() != null) {
+            boolean updated = policy.isLibUpdatePossible();
+            if (updated) course.updateCore3(requestDto.getCore3());
+            results.put("core3", updated);
+        }
+        if (requestDto.getCore4() != null) {
+            boolean updated = policy.isLibUpdatePossible();
+            if (updated) course.updateCore4(requestDto.getCore4());
+            results.put("core4", updated);
+        }
+
+        return TimetableSubmitResponseDto.builder()
+                .updateResults(results)
+                .build();
         // TODO 시간표 저장 : 장학금 코드에서 시간표 데이터 어떻게 받는지 확인 필요, 저장할 필요 없으면 미구현할 것
-        // TODO 결과 리턴
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/course/CourseService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/course/CourseService.java
@@ -1,4 +1,4 @@
-package sookmyung.noonsongmaker.Service;
+package sookmyung.noonsongmaker.Service.course;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -63,6 +63,9 @@ public class CourseService {
         Course course = courseRepository.findByUser(user)
                 .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
 
-        course.updateCourse(requestDto);
+
+        course.updateCredits(requestDto.getCoreCredits(), requestDto.getElectiveCredits());
+        course.updateRequired(requestDto.getRequiredDigital(), requestDto.getRequiredFuture(), requestDto.getRequiredEng(), requestDto.getRequiredLogic());
+        course.updateCore(requestDto.getCore1(), requestDto.getCore2(), requestDto.getCore3(), requestDto.getCore4());
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/course/CourseService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/course/CourseService.java
@@ -62,10 +62,43 @@ public class CourseService {
     public void updateTimetable(User user, TimetableSubmitRequestDto requestDto) {
         Course course = courseRepository.findByUser(user)
                 .orElseThrow(() -> new NoSuchElementException("수강 정보 소유자 없음"));
+        TimetableUpdatePolicy policy = new TimetableUpdatePolicy(user.getCurrentChapter());
 
+        if (requestDto.getCoreCredits() != null && policy.isMajorUpdatePossible()) {
+            course.updateCoreCredits(requestDto.getCoreCredits());
+            // TODO responseDto에 결과 저장 : 프론트와 형식 협의 필요
+        }
+        if (requestDto.getElectiveCredits() != null && policy.isMajorUpdatePossible()) {
+            course.updateElectiveCredits(requestDto.getElectiveCredits());
+        }
 
-        course.updateCredits(requestDto.getCoreCredits(), requestDto.getElectiveCredits());
-        course.updateRequired(requestDto.getRequiredDigital(), requestDto.getRequiredFuture(), requestDto.getRequiredEng(), requestDto.getRequiredLogic());
-        course.updateCore(requestDto.getCore1(), requestDto.getCore2(), requestDto.getCore3(), requestDto.getCore4());
+        if (requestDto.getRequiredDigital() != null && policy.isLibUpdatePossible()) {
+            course.updateRequiredDigital(requestDto.getRequiredDigital());
+        }
+        if (requestDto.getRequiredFuture() != null && policy.isLibUpdatePossible()) {
+            course.updateRequiredFuture(requestDto.getRequiredFuture());
+        }
+        if (requestDto.getRequiredEng() != null && policy.isLibUpdatePossible()) {
+            course.updateRequiredEng(requestDto.getRequiredEng());
+        }
+        if (requestDto.getRequiredLogic() != null && policy.isLibUpdatePossible()) {
+            course.updateRequiredLogic(requestDto.getRequiredLogic());
+        }
+
+        if (requestDto.getCore1() != null && policy.isLibUpdatePossible()) {
+            course.updateCore1(requestDto.getCore1());
+        }
+        if (requestDto.getCore2() != null && policy.isLibUpdatePossible()) {
+            course.updateCore2(requestDto.getCore2());
+        }
+        if (requestDto.getCore3() != null && policy.isLibUpdatePossible()) {
+            course.updateCore3(requestDto.getCore3());
+        }
+        if (requestDto.getCore4() != null && policy.isLibUpdatePossible()) {
+            course.updateCore4(requestDto.getCore4());
+        }
+
+        // TODO 시간표 저장 : 장학금 코드에서 시간표 데이터 어떻게 받는지 확인 필요, 저장할 필요 없으면 미구현할 것
+        // TODO 결과 리턴
     }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/course/TimetableUpdatePolicy.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/course/TimetableUpdatePolicy.java
@@ -1,0 +1,41 @@
+package sookmyung.noonsongmaker.Service.course;
+
+import sookmyung.noonsongmaker.Entity.Chapter;
+
+import java.util.Random;
+
+public class TimetableUpdatePolicy {
+    private final Chapter chapter;
+    private final Random random = new Random();
+
+    public TimetableUpdatePolicy(Chapter chapter) {
+        this.chapter = chapter;
+    }
+
+    public boolean isMajorUpdatePossible() {
+        return random.nextDouble() < getMajorSuccessRate();
+    }
+
+    public boolean isLibUpdatePossible() {
+        return random.nextDouble() < getLibSuccessRate();
+    }
+
+    private double getMajorSuccessRate() {
+        return switch (chapter) {
+            case SEM_S_1, SEM_W_1, SEM_S_2, SEM_W_2 -> 0.8;
+            case SEM_S_3, SEM_W_3 -> 0.9;
+            case SEM_S_4, SEM_W_4 -> 1.0;
+            default -> throw new IllegalStateException("Unexpected value: " + chapter);
+        };
+    }
+
+    private double getLibSuccessRate() {
+        return switch (chapter) {
+            case SEM_S_1, SEM_W_1 -> 0.9;
+            case SEM_S_2, SEM_W_2 -> 0.1;
+            case SEM_S_3, SEM_W_3 -> 0.2;
+            case SEM_S_4, SEM_W_4 -> 1.0;
+            default -> throw new IllegalStateException("Unexpected value: " + chapter);
+        };
+    }
+}

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/jwt/CurrentUser.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/jwt/CurrentUser.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER) // 매개변수에서만 사용
 @Retention(RetentionPolicy.RUNTIME) // 어노테이션이 런타임 동안 유지
-@AuthenticationPrincipal // @CurrentUser 가 붙은 매개변수에 현재 인증된 사용자 객체 주입
+@AuthenticationPrincipal(expression = "user") // @CurrentUser 가 붙은 매개변수에 현재 인증된 사용자 객체 주입
 public @interface CurrentUser {
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/jwt/JwtAuthorizeFilter.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/jwt/JwtAuthorizeFilter.java
@@ -4,8 +4,10 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
 import sookmyung.noonsongmaker.Entity.User;
@@ -14,6 +16,7 @@ import sookmyung.noonsongmaker.Repository.UserRepository;
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 public class JwtAuthorizeFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
@@ -27,17 +30,29 @@ public class JwtAuthorizeFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
+
+        log.info("📌 [JwtAuthorizeFilter] 요청 URL: {}", request.getRequestURI());
+
         String jwt = jwtProvider.resolveToken(request);
+        log.info("📌 [JwtAuthorizeFilter] 추출된 JWT: {}", jwt);
 
         if (jwt != null && jwtProvider.validateToken(jwt)) {
+            log.info("✅ [JwtAuthorizeFilter] JWT가 유효함");
             String email = jwtProvider.getEmailFromToken(jwt);
+            log.info("📌 [JwtAuthorizeFilter] JWT에서 추출한 이메일: {}", email);
 
             User user = userRepository.findByEmail(email)
                     .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
+            log.info("✅ [JwtAuthorizeFilter] 데이터베이스에서 조회된 사용자: {} (ID: {})", user.getEmail(), user.getId());
+
+            UserDetailsImpl userDetails = new UserDetailsImpl(user);
+            log.info("✅ [JwtAuthorizeFilter] SecurityContext에 저장된 인증 객체: {}", SecurityContextHolder.getContext().getAuthentication());
+
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(user, null, List.of());
+                    new UsernamePasswordAuthenticationToken(userDetails, null, List.of());
             SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info("✅ [JwtAuthorizeFilter] SecurityContext에 저장된 사용자: {}", user.getEmail());
         }
 
         filterChain.doFilter(request, response);

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/jwt/JwtAuthorizeFilter.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/jwt/JwtAuthorizeFilter.java
@@ -4,10 +4,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
 import sookmyung.noonsongmaker.Entity.User;
@@ -16,7 +14,6 @@ import sookmyung.noonsongmaker.Repository.UserRepository;
 import java.io.IOException;
 import java.util.List;
 
-@Slf4j
 public class JwtAuthorizeFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
@@ -31,28 +28,21 @@ public class JwtAuthorizeFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        log.info("📌 [JwtAuthorizeFilter] 요청 URL: {}", request.getRequestURI());
 
         String jwt = jwtProvider.resolveToken(request);
-        log.info("📌 [JwtAuthorizeFilter] 추출된 JWT: {}", jwt);
 
         if (jwt != null && jwtProvider.validateToken(jwt)) {
-            log.info("✅ [JwtAuthorizeFilter] JWT가 유효함");
             String email = jwtProvider.getEmailFromToken(jwt);
-            log.info("📌 [JwtAuthorizeFilter] JWT에서 추출한 이메일: {}", email);
 
             User user = userRepository.findByEmail(email)
                     .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
-            log.info("✅ [JwtAuthorizeFilter] 데이터베이스에서 조회된 사용자: {} (ID: {})", user.getEmail(), user.getId());
 
             UserDetailsImpl userDetails = new UserDetailsImpl(user);
-            log.info("✅ [JwtAuthorizeFilter] SecurityContext에 저장된 인증 객체: {}", SecurityContextHolder.getContext().getAuthentication());
 
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(userDetails, null, List.of());
             SecurityContextHolder.getContext().setAuthentication(authentication);
-            log.info("✅ [JwtAuthorizeFilter] SecurityContext에 저장된 사용자: {}", user.getEmail());
         }
 
         filterChain.doFilter(request, response);

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/jwt/UserDetailsImpl.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/jwt/UserDetailsImpl.java
@@ -28,4 +28,8 @@ public class UserDetailsImpl implements UserDetails {
     public String getUsername() {
         return user.getEmail();
     }
+
+    public User getUser() {
+        return this.user;
+    }
 }

--- a/noonsongmaker/src/main/resources/http/CourseTest.http
+++ b/noonsongmaker/src/main/resources/http/CourseTest.http
@@ -1,0 +1,8 @@
+### GET request to example server
+GET https://examples.http-client.intellij.net/get
+    ?generated-in=IntelliJ IDEA
+
+### 직전 학기까지의 수강 정보 반환
+GET http://localhost:8080/course/main
+Content-Type: application/json
+Cookie: ACCESS_TOKEN=


### PR DESCRIPTION
## Issue 번호
<!-- (이슈번호)를 지우고 이슈 번호를 기입하면 해당 이슈가 자동 close 처리됩니다-->
close #7 

## ✅ PR 전 확인!
- [x] 변경 사항에 대한 테스트 완료
- [x] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용

<!-- 무엇을 왜 수정했는지 설명하면 리뷰어에게 도움이 됩니다!-->
- 직전 학기까지 수강한 전필/전선 및 전공, 전공타입, 학기 정보 리턴 api
- 직전 학기까지의 교필 수강 현황 정보 리턴 api
- 직전 학기까지의 교핵 수강 현황 정보 리턴 api

- 수강신청 api

## 🖼️ 관련 스크린샷 (선택)


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
- service의 수강신청 메소드는 향후 리팩토링 여지가 있습니다. 지피티로부터 runnable을 통한 동적 처리 로직을 추천 받았으나 해당 방식 관련 지식이 없어 학습 후 채택여부 결정할 예정입니다.
- requestDto에서 전필 과목 변수에 대해, 프론트에서 사용하기 쉽도록 한글 변수명을 매핑하는 방식을 고려중입니다.(TODO 참고)