### PR TITLE
[Feat]: 인턴 수행 중 스트레스 예외 발생 시 스트레스 스탯을 60으로 조정

### DIFF
--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/StatusInfo.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Entity/StatusInfo.java
@@ -140,4 +140,6 @@ public class StatusInfo {
     public void updateGlobalAssess(int amount) { this.globalAssess = changeValueWithinBound(this.globalAssess, amount); }
 
     public void updateCoin(int amount) { this.coin = Math.max(0, this.coin + amount); }
+
+    public void updateStressWhenExp(int amount) { this.stress = amount; }
 }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/plan/PlanService.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/plan/PlanService.java
@@ -2,8 +2,6 @@ package sookmyung.noonsongmaker.Service.plan;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import sookmyung.noonsongmaker.Dto.plan.PlanExecuteRequestDto;
 import sookmyung.noonsongmaker.Dto.plan.PlanExecuteResponseDto;
@@ -17,7 +15,6 @@ import java.util.*;
 @Service
 @RequiredArgsConstructor
 public class PlanService {
-    private final Logger log = LoggerFactory.getLogger(PlanService.class);
     private final StatusInfoRepository statusInfoRepository;
     private final PlanRepository planRepository;
     private final PlanStatusRepository planStatusRepository;
@@ -126,20 +123,21 @@ public class PlanService {
         }
 
         for (Effect effect : effects) {
-            applyEffect(status, effect);
+            applyEffect(status, effect, plan);
             result.addEffect(effect.getStatusName(), effect.getChangeAmount());
         }
 
         return result;
     }
 
-    private void applyEffect(StatusInfo status, Effect effect) {
+    private void applyEffect(StatusInfo status, Effect effect, Plan plan) {
         if (effect.getStatusName() == StatusName.STRESS) {
             int currentStress = status.getStress();
             int updatedStress = currentStress + effect.getChangeAmount();
 
             if (updatedStress >= 100) {
                 // log.error(실행 중 스트레스 100 도달로 중단됨");
+                if (plan.getPlanName().equals("인턴")) status.updateStressWhenExp(60);
                 throw new StressOverflowException();
             }
         }

--- a/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/sse/SseEmitterRegistry.java
+++ b/noonsongmaker/src/main/java/sookmyung/noonsongmaker/Service/sse/SseEmitterRegistry.java
@@ -35,7 +35,7 @@ public class SseEmitterRegistry {
         emitters.remove(userId);
     }
 
-    public Collection<SseEmitter> getAllEmitters() {
-        return emitters.values();
+    public Map<Long, SseEmitter> getAllEmittersWithIds() {
+        return emitters;
     }
 }


### PR DESCRIPTION
## Issue 번호
<!-- (이슈번호)를 지우고 이슈 번호를 기입하면 해당 이슈가 자동 close 처리됩니다-->
close #(이슈번호)

## ✅ PR 전 확인!
- [x] 변경 사항에 대한 테스트 완료
- [x] PR 제목 컨벤션 준수
  <!--PR 제목은 `[유형]: [내용]` 형식-->

## 💻 작업 내용

<!-- 무엇을 왜 수정했는지 설명하면 리뷰어에게 도움이 됩니다!-->
- 스트레스 예외 발생 시 계획 제출 시점으로 롤백하는데, 이때 인턴은 고정 계획이므로 게임오버가 무한 루프로 발생했음
- 이에 비즈니스 로직을 변경해, 인턴에 한해 예외 발생 시 스트레스 스탯을 60으로 임의 조정함.
  60 + (일일증가량2*14일) = 88. 플레이어가 인턴 이후의 계획 구성을 신중히 하도록 유도하게 됨.

## 🖼️ 관련 스크린샷 (선택)


## ❗️Remark
<!--팀원이 알아야 하는 내용이 있다면 적어주세요-->
- 내용
